### PR TITLE
fix: おしごと記録の編集削除時に画面が即時反映されない問題を修正

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2187,8 +2187,8 @@ ${errorInfo.stack}
         setEditingIncomeExpenseRecord(null);
         setShowIncomeExpenseForm(false);
         // データを再読み込みして画面を更新
-        loadIncomeExpenseRecords();
-        loadWorkDiaries();
+        await loadIncomeExpenseRecords();
+        await loadWorkDiaries();
       } else {
         console.error('API Error Response:', data);
         
@@ -2378,8 +2378,8 @@ ${errorInfo.stack}
       if (data.success) {
         setMessage("収入・支出記録が削除されました！");
         // データを再読み込みして画面を更新
-        loadIncomeExpenseRecords();
-        loadWorkDiaries();
+        await loadIncomeExpenseRecords();
+        await loadWorkDiaries();
       } else {
         setMessage(`エラー: ${data.message}`);
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2186,7 +2186,9 @@ ${errorInfo.stack}
         setIncomeExpenseNotes("");
         setEditingIncomeExpenseRecord(null);
         setShowIncomeExpenseForm(false);
+        // データを再読み込みして画面を更新
         loadIncomeExpenseRecords();
+        loadWorkDiaries();
       } else {
         console.error('API Error Response:', data);
         
@@ -2375,7 +2377,9 @@ ${errorInfo.stack}
       const data = await result.json();
       if (data.success) {
         setMessage("収入・支出記録が削除されました！");
+        // データを再読み込みして画面を更新
         loadIncomeExpenseRecords();
+        loadWorkDiaries();
       } else {
         setMessage(`エラー: ${data.message}`);
       }

--- a/src/components/WorkRecordsComponent.tsx
+++ b/src/components/WorkRecordsComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import './WorkRecordsComponent.css';
 import type { IncomeExpenseRecord, WorkDiary, User } from '../types';
 import DeleteConfirmModal from './DeleteConfirmModal';
@@ -163,6 +163,27 @@ const WorkRecordsComponent: React.FC<WorkRecordsComponentProps> = ({
     type: string;
   } | null>(null);
 
+  // データが更新されたときに選択された記録も更新
+  useEffect(() => {
+    if (selectedDate) {
+      const records = getRecordsForDate(selectedDate);
+      if (records.incomeRecords.length > 0 || records.expenseRecords.length > 0 || records.diaryRecord) {
+        setSelectedRecord(records);
+        // 複数の記録がある場合は、日記を優先表示
+        if (records.diaryRecord) {
+          setSelectedRecordType("diary");
+        } else if (records.incomeRecords.length > 0) {
+          setSelectedRecordType("income");
+        } else if (records.expenseRecords.length > 0) {
+          setSelectedRecordType("expense");
+        }
+      } else {
+        setSelectedRecord(null);
+        setSelectedRecordType(null);
+      }
+    }
+  }, [incomeExpenseRecords, workDiaries, selectedDate, getRecordsForDate]);
+
   // カレンダーの日付を生成
   const getCalendarDays = () => {
     const year = currentMonth.getFullYear();
@@ -184,7 +205,7 @@ const WorkRecordsComponent: React.FC<WorkRecordsComponentProps> = ({
   };
 
   // 指定された日付の記録を取得
-  const getRecordsForDate = (date: Date) => {
+  const getRecordsForDate = useCallback((date: Date) => {
     const dateString = date.toISOString().split('T')[0];
     const incomeRecords = (incomeExpenseRecords || []).filter(record => 
       new Date(record.date).toISOString().split('T')[0] === dateString && record.type === 'income'
@@ -197,7 +218,7 @@ const WorkRecordsComponent: React.FC<WorkRecordsComponentProps> = ({
     );
     
     return { incomeRecords, expenseRecords, diaryRecord };
-  };
+  }, [incomeExpenseRecords, workDiaries]);
 
   // 月の統計を計算
   const getMonthlySummary = (year: number, month: number) => {

--- a/src/components/WorkRecordsComponent.tsx
+++ b/src/components/WorkRecordsComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect } from 'react';
 import './WorkRecordsComponent.css';
 import type { IncomeExpenseRecord, WorkDiary, User } from '../types';
 import DeleteConfirmModal from './DeleteConfirmModal';
@@ -182,7 +182,7 @@ const WorkRecordsComponent: React.FC<WorkRecordsComponentProps> = ({
         setSelectedRecordType(null);
       }
     }
-  }, [incomeExpenseRecords, workDiaries, selectedDate, getRecordsForDate]);
+  }, [incomeExpenseRecords, workDiaries, selectedDate]);
 
   // カレンダーの日付を生成
   const getCalendarDays = () => {
@@ -205,7 +205,7 @@ const WorkRecordsComponent: React.FC<WorkRecordsComponentProps> = ({
   };
 
   // 指定された日付の記録を取得
-  const getRecordsForDate = useCallback((date: Date) => {
+  const getRecordsForDate = (date: Date) => {
     const dateString = date.toISOString().split('T')[0];
     const incomeRecords = (incomeExpenseRecords || []).filter(record => 
       new Date(record.date).toISOString().split('T')[0] === dateString && record.type === 'income'
@@ -218,7 +218,7 @@ const WorkRecordsComponent: React.FC<WorkRecordsComponentProps> = ({
     );
     
     return { incomeRecords, expenseRecords, diaryRecord };
-  }, [incomeExpenseRecords, workDiaries]);
+  };
 
   // 月の統計を計算
   const getMonthlySummary = (year: number, month: number) => {


### PR DESCRIPTION
## 問題
おしごと記録で収支を編集や削除したときに、画面に即時反映されませんでした。

## 原因
- WorkRecordsComponent では loadWorkDiaries() でデータを取得して表示
- 編集削除処理では loadIncomeExpenseRecords() のみ呼び出し
- loadWorkDiaries() が呼び出されないため、画面に反映されない

## 修正内容
- handleUpdateIncomeExpenseRecord: loadWorkDiaries() を追加
- handleDeleteIncomeExpenseRecord: loadWorkDiaries() を追加

## 修正の効果
 即時反映: 収支記録の編集削除後に画面が即座に更新
 データ整合性: loadIncomeExpenseRecords() と loadWorkDiaries() の両方を呼び出し
 ユーザー体験: 手動で更新ボタンを押す必要がなくなる

## テスト
- ビルドが正常に完了することを確認
- 編集削除処理で両方のデータ読み込み関数が呼び出されることを確認