### PR TITLE
feat: 更新要望UIを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "work-time-tracker",
   "private": true,
-  "version": "1.0.4",
+  "version": "1.0.5",
   "packageManager": "pnpm@10.15.1",
   "engines": {
     "node": ">=20.0.0 <21.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,16 @@ import SimpleErrorReportingModal from "./components/SimpleErrorReportingModal";
 import UpdateRequestModal from "./components/UpdateRequestModal";
 import BugReportModal from "./components/BugReportModal";
 import { setErrorReportCallback, reportApiError } from "./utils/apiClient";
+import {
+  formatUpdateRequestContent,
+  formatBugReportContent,
+  getUpdateRequestTags,
+  getBugReportTags,
+  formatUpdateRequestTitle,
+  formatBugReportTitle,
+  type UpdateRequestData,
+  type BugReportData,
+} from "./utils/requestFormatters";
 
 import type {
   User,
@@ -4214,12 +4224,7 @@ User Agent: ${userAgent}
   };
 
   // 更新要望送信処理
-  const handleUpdateRequest = async (updateRequest: {
-    title: string;
-    content: string;
-    category: string;
-    priority: string;
-  }) => {
+  const handleUpdateRequest = async (updateRequest: UpdateRequestData) => {
     try {
       const token = localStorage.getItem("access_token");
       
@@ -4231,10 +4236,10 @@ User Agent: ${userAgent}
           Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify({
-          title: `[更新要望] ${updateRequest.title}`,
-          content: `**カテゴリ:** ${updateRequest.category}\n**優先度:** ${updateRequest.priority}\n\n**詳細内容:**\n${updateRequest.content}`,
+          title: formatUpdateRequestTitle(updateRequest.title),
+          content: formatUpdateRequestContent(updateRequest),
           category: "更新要望",
-          tags: ["更新要望", "改善提案", "フィードバック"],
+          tags: getUpdateRequestTags(),
           isPublic: true,
           isFamilyOnly: false,
           isAdminOnly: false,
@@ -4257,15 +4262,7 @@ User Agent: ${userAgent}
   };
 
   // 不具合報告送信処理
-  const handleBugReport = async (bugReport: {
-    title: string;
-    content: string;
-    category: string;
-    severity: string;
-    steps: string;
-    expectedBehavior: string;
-    actualBehavior: string;
-  }) => {
+  const handleBugReport = async (bugReport: BugReportData) => {
     try {
       const token = localStorage.getItem("access_token");
       
@@ -4277,10 +4274,10 @@ User Agent: ${userAgent}
           Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify({
-          title: `[不具合報告] ${bugReport.title}`,
-          content: `**カテゴリ:** ${bugReport.category}\n**重要度:** ${bugReport.severity}\n\n**再現手順:**\n${bugReport.steps || '記載なし'}\n\n**期待される動作:**\n${bugReport.expectedBehavior || '記載なし'}\n\n**実際の動作:**\n${bugReport.actualBehavior || '記載なし'}\n\n**詳細説明:**\n${bugReport.content}`,
+          title: formatBugReportTitle(bugReport.title),
+          content: formatBugReportContent(bugReport),
           category: "不具合報告",
-          tags: ["不具合報告", "バグ", "エラー"],
+          tags: getBugReportTags(),
           isPublic: true,
           isFamilyOnly: false,
           isAdminOnly: false,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,7 @@ import {
 import LanguageFontSettings from "./components/LanguageFontSettings";
 import { cookingRecipes, getRecipePhases } from "./constants/cookingRecipes";
 import SimpleErrorReportingModal from "./components/SimpleErrorReportingModal";
+import UpdateRequestModal from "./components/UpdateRequestModal";
 import { setErrorReportCallback, reportApiError } from "./utils/apiClient";
 
 import type {
@@ -93,6 +94,9 @@ function App() {
   const [currentError, setCurrentError] = useState<Error | null>(null);
   const [showSimpleErrorModal, setShowSimpleErrorModal] = useState(false);
   const [errorModalButtonPosition, setErrorModalButtonPosition] = useState<{ x: number; y: number } | undefined>(undefined);
+
+  // 更新要望関連の状態
+  const [showUpdateRequestModal, setShowUpdateRequestModal] = useState(false);
 
   // 各機能のローディング状態（LoadingStateManagerで管理）
   const [publicMemosLoading, setPublicMemosLoading] = useState(false);
@@ -4205,6 +4209,49 @@ User Agent: ${userAgent}
     }
   };
 
+  // 更新要望送信処理
+  const handleUpdateRequest = async (updateRequest: {
+    title: string;
+    content: string;
+    category: string;
+    priority: string;
+  }) => {
+    try {
+      const token = localStorage.getItem("access_token");
+      
+      // 更新要望を公開メモとして投稿
+      const response = await fetch("/api/memos", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          title: `[更新要望] ${updateRequest.title}`,
+          content: `**カテゴリ:** ${updateRequest.category}\n**優先度:** ${updateRequest.priority}\n\n**詳細内容:**\n${updateRequest.content}`,
+          category: "更新要望",
+          tags: ["更新要望", "改善提案", "フィードバック"],
+          isPublic: true,
+          isFamilyOnly: false,
+          isAdminOnly: false,
+          postType: "update_request"
+        }),
+      });
+
+      if (response.ok) {
+        setMessage("更新要望を送信しました。ありがとうございます。");
+        setShowUpdateRequestModal(false);
+      } else {
+        const errorData = await response.json();
+        throw new Error(errorData.message || "更新要望の送信に失敗しました");
+      }
+    } catch (error) {
+      console.error("更新要望送信エラー:", error);
+      setMessage("更新要望の送信に失敗しました。もう一度お試しください。");
+      throw error;
+    }
+  };
+
   // エラー報告の送信処理
   const handleErrorReport = async (errorInfo: ApiErrorInfo) => {
     try {
@@ -5653,6 +5700,7 @@ User Agent: ${userAgent}
             setShowFeatureSettings={setShowFeatureSettings}
             loadUserSettings={loadUserSettings}
             isTimeTrackingActive={isTimeTrackingActive}
+            onUpdateRequestClick={() => setShowUpdateRequestModal(true)}
           />
 
           {/* バージョン情報 */}
@@ -6411,6 +6459,13 @@ User Agent: ${userAgent}
           onClose={() => setShowSimpleErrorModal(false)}
           onSubmit={handleSimpleErrorReport}
           errorInfo={getErrorInfo(currentError)}
+        />
+
+        {/* 更新要望モーダル */}
+        <UpdateRequestModal
+          isOpen={showUpdateRequestModal}
+          onClose={() => setShowUpdateRequestModal(false)}
+          onSubmit={handleUpdateRequest}
         />
       </div>
     );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,7 @@ import LanguageFontSettings from "./components/LanguageFontSettings";
 import { cookingRecipes, getRecipePhases } from "./constants/cookingRecipes";
 import SimpleErrorReportingModal from "./components/SimpleErrorReportingModal";
 import UpdateRequestModal from "./components/UpdateRequestModal";
+import BugReportModal from "./components/BugReportModal";
 import { setErrorReportCallback, reportApiError } from "./utils/apiClient";
 
 import type {
@@ -97,6 +98,9 @@ function App() {
 
   // 更新要望関連の状態
   const [showUpdateRequestModal, setShowUpdateRequestModal] = useState(false);
+
+  // 不具合報告関連の状態
+  const [showBugReportModal, setShowBugReportModal] = useState(false);
 
   // 各機能のローディング状態（LoadingStateManagerで管理）
   const [publicMemosLoading, setPublicMemosLoading] = useState(false);
@@ -4252,6 +4256,52 @@ User Agent: ${userAgent}
     }
   };
 
+  // 不具合報告送信処理
+  const handleBugReport = async (bugReport: {
+    title: string;
+    content: string;
+    category: string;
+    severity: string;
+    steps: string;
+    expectedBehavior: string;
+    actualBehavior: string;
+  }) => {
+    try {
+      const token = localStorage.getItem("access_token");
+      
+      // 不具合報告を公開メモとして投稿
+      const response = await fetch("/api/memos", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          title: `[不具合報告] ${bugReport.title}`,
+          content: `**カテゴリ:** ${bugReport.category}\n**重要度:** ${bugReport.severity}\n\n**再現手順:**\n${bugReport.steps || '記載なし'}\n\n**期待される動作:**\n${bugReport.expectedBehavior || '記載なし'}\n\n**実際の動作:**\n${bugReport.actualBehavior || '記載なし'}\n\n**詳細説明:**\n${bugReport.content}`,
+          category: "不具合報告",
+          tags: ["不具合報告", "バグ", "エラー"],
+          isPublic: true,
+          isFamilyOnly: false,
+          isAdminOnly: false,
+          postType: "error_report"
+        }),
+      });
+
+      if (response.ok) {
+        setMessage("不具合報告を送信しました。ありがとうございます。");
+        setShowBugReportModal(false);
+      } else {
+        const errorData = await response.json();
+        throw new Error(errorData.message || "不具合報告の送信に失敗しました");
+      }
+    } catch (error) {
+      console.error("不具合報告送信エラー:", error);
+      setMessage("不具合報告の送信に失敗しました。もう一度お試しください。");
+      throw error;
+    }
+  };
+
   // エラー報告の送信処理
   const handleErrorReport = async (errorInfo: ApiErrorInfo) => {
     try {
@@ -5701,6 +5751,7 @@ User Agent: ${userAgent}
             loadUserSettings={loadUserSettings}
             isTimeTrackingActive={isTimeTrackingActive}
             onUpdateRequestClick={() => setShowUpdateRequestModal(true)}
+            onBugReportClick={() => setShowBugReportModal(true)}
           />
 
           {/* バージョン情報 */}
@@ -6466,6 +6517,13 @@ User Agent: ${userAgent}
           isOpen={showUpdateRequestModal}
           onClose={() => setShowUpdateRequestModal(false)}
           onSubmit={handleUpdateRequest}
+        />
+
+        {/* 不具合報告モーダル */}
+        <BugReportModal
+          isOpen={showBugReportModal}
+          onClose={() => setShowBugReportModal(false)}
+          onSubmit={handleBugReport}
         />
       </div>
     );

--- a/src/components/BugReportModal.css
+++ b/src/components/BugReportModal.css
@@ -1,0 +1,271 @@
+/* BugReportModal.css - 不具合報告モーダルのスタイル */
+
+.bug-report-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  backdrop-filter: blur(4px);
+}
+
+.bug-report-modal {
+  background: white;
+  border-radius: 16px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  width: 90%;
+  max-width: 700px;
+  max-height: 90vh;
+  overflow-y: auto;
+  animation: modalSlideIn 0.3s ease-out;
+}
+
+@keyframes modalSlideIn {
+  from {
+    opacity: 0;
+    transform: translateY(-20px) scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.bug-report-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 2rem;
+  border-bottom: 2px solid #f0f0f0;
+  background: linear-gradient(135deg, #ff6b6b 0%, #ee5a52 100%);
+  color: white;
+  border-radius: 16px 16px 0 0;
+}
+
+.bug-report-modal-header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.bug-report-modal-header h2 i {
+  font-size: 1.3rem;
+}
+
+.close-button {
+  background: rgba(255, 255, 255, 0.2);
+  border: none;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: white;
+  font-size: 1.2rem;
+  transition: all 0.2s ease;
+}
+
+.close-button:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.3);
+  transform: scale(1.1);
+}
+
+.close-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.bug-report-form {
+  padding: 2rem;
+}
+
+.form-group {
+  margin-bottom: 1.5rem;
+}
+
+.form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.form-group label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+  color: #333;
+  font-size: 0.95rem;
+}
+
+.form-group label i {
+  color: #ff6b6b;
+  font-size: 1rem;
+}
+
+.required {
+  color: #e74c3c;
+  font-weight: 700;
+}
+
+.form-group input,
+.form-group select,
+.form-group textarea {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: 2px solid #e0e0e0;
+  border-radius: 8px;
+  font-size: 0.95rem;
+  font-family: inherit;
+  transition: all 0.3s ease;
+  background: #fafafa;
+}
+
+.form-group input:focus,
+.form-group select:focus,
+.form-group textarea:focus {
+  outline: none;
+  border-color: #ff6b6b;
+  background: white;
+  box-shadow: 0 0 0 3px rgba(255, 107, 107, 0.1);
+}
+
+.form-group input:disabled,
+.form-group select:disabled,
+.form-group textarea:disabled {
+  background: #f5f5f5;
+  color: #999;
+  cursor: not-allowed;
+}
+
+.form-group textarea {
+  resize: vertical;
+  min-height: 80px;
+  line-height: 1.6;
+}
+
+.character-count {
+  text-align: right;
+  font-size: 0.8rem;
+  color: #666;
+  margin-top: 0.25rem;
+}
+
+.form-actions {
+  display: flex;
+  gap: 1rem;
+  justify-content: flex-end;
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid #e0e0e0;
+}
+
+.cancel-button,
+.submit-button {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  min-width: 120px;
+  justify-content: center;
+}
+
+.cancel-button {
+  background: #f8f9fa;
+  color: #6c757d;
+  border: 2px solid #e9ecef;
+}
+
+.cancel-button:hover:not(:disabled) {
+  background: #e9ecef;
+  color: #495057;
+  transform: translateY(-1px);
+}
+
+.submit-button {
+  background: linear-gradient(135deg, #ff6b6b 0%, #ee5a52 100%);
+  color: white;
+  box-shadow: 0 4px 12px rgba(255, 107, 107, 0.3);
+}
+
+.submit-button:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(255, 107, 107, 0.4);
+}
+
+.submit-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.cancel-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+}
+
+/* レスポンシブ対応 */
+@media (max-width: 768px) {
+  .bug-report-modal {
+    width: 95%;
+    margin: 1rem;
+  }
+  
+  .bug-report-modal-header {
+    padding: 1rem 1.5rem;
+  }
+  
+  .bug-report-modal-header h2 {
+    font-size: 1.3rem;
+  }
+  
+  .bug-report-form {
+    padding: 1.5rem;
+  }
+  
+  .form-row {
+    grid-template-columns: 1fr;
+    gap: 0;
+  }
+  
+  .form-actions {
+    flex-direction: column;
+  }
+  
+  .cancel-button,
+  .submit-button {
+    width: 100%;
+  }
+}
+
+@media (max-width: 480px) {
+  .bug-report-modal {
+    width: 100%;
+    height: 100%;
+    border-radius: 0;
+    max-height: none;
+  }
+  
+  .bug-report-modal-header {
+    border-radius: 0;
+  }
+}

--- a/src/components/BugReportModal.css
+++ b/src/components/BugReportModal.css
@@ -149,6 +149,35 @@
   cursor: not-allowed;
 }
 
+.form-group input.error,
+.form-group select.error,
+.form-group textarea.error {
+  border-color: #e74c3c;
+  background: #fdf2f2;
+}
+
+.error-message {
+  color: #e74c3c;
+  font-size: 0.85rem;
+  margin-top: 0.25rem;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.error-message i {
+  font-size: 0.9rem;
+}
+
+.submit-error {
+  background: #fdf2f2;
+  border: 1px solid #fecaca;
+  border-radius: 6px;
+  padding: 0.75rem;
+  margin-bottom: 1rem;
+  color: #dc2626;
+}
+
 .form-group textarea {
   resize: vertical;
   min-height: 80px;

--- a/src/components/BugReportModal.tsx
+++ b/src/components/BugReportModal.tsx
@@ -28,6 +28,7 @@ const BugReportModal: React.FC<BugReportModalProps> = ({
   const [expectedBehavior, setExpectedBehavior] = useState('');
   const [actualBehavior, setActualBehavior] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errors, setErrors] = useState<{[key: string]: string}>({});
 
   const categories = [
     { value: 'ui', label: 'UI/UX問題' },
@@ -46,15 +47,33 @@ const BugReportModal: React.FC<BugReportModalProps> = ({
     { value: 'critical', label: '緊急' },
   ];
 
+  const validateForm = () => {
+    const newErrors: {[key: string]: string} = {};
+    
+    if (!title.trim()) {
+      newErrors.title = 'タイトルは必須項目です。';
+    }
+    if (!content.trim()) {
+      newErrors.content = '詳細説明は必須項目です。';
+    }
+    if (!category) {
+      newErrors.category = 'カテゴリは必須項目です。';
+    }
+    
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     
-    if (!title.trim() || !content.trim() || !category) {
-      alert('タイトル、内容、カテゴリは必須項目です。');
+    if (!validateForm()) {
       return;
     }
 
     setIsSubmitting(true);
+    setErrors({});
+    
     try {
       await onSubmit({
         title: title.trim(),
@@ -74,10 +93,11 @@ const BugReportModal: React.FC<BugReportModalProps> = ({
       setSteps('');
       setExpectedBehavior('');
       setActualBehavior('');
+      setErrors({});
       onClose();
     } catch (error) {
       console.error('不具合報告の送信に失敗しました:', error);
-      alert('不具合報告の送信に失敗しました。もう一度お試しください。');
+      setErrors({ submit: '不具合報告の送信に失敗しました。もう一度お試しください。' });
     } finally {
       setIsSubmitting(false);
     }
@@ -127,8 +147,10 @@ const BugReportModal: React.FC<BugReportModalProps> = ({
               disabled={isSubmitting}
               maxLength={100}
               required
+              className={errors.title ? 'error' : ''}
             />
             <div className="character-count">{title.length}/100</div>
+            {errors.title && <div className="error-message">{errors.title}</div>}
           </div>
 
           <div className="form-row">
@@ -143,6 +165,7 @@ const BugReportModal: React.FC<BugReportModalProps> = ({
                 onChange={(e) => setCategory(e.target.value)}
                 disabled={isSubmitting}
                 required
+                className={errors.category ? 'error' : ''}
               >
                 <option value="">カテゴリを選択してください</option>
                 {categories.map((cat) => (
@@ -151,6 +174,7 @@ const BugReportModal: React.FC<BugReportModalProps> = ({
                   </option>
                 ))}
               </select>
+              {errors.category && <div className="error-message">{errors.category}</div>}
             </div>
 
             <div className="form-group">
@@ -238,9 +262,18 @@ const BugReportModal: React.FC<BugReportModalProps> = ({
               rows={4}
               maxLength={1000}
               required
+              className={errors.content ? 'error' : ''}
             />
             <div className="character-count">{content.length}/1000</div>
+            {errors.content && <div className="error-message">{errors.content}</div>}
           </div>
+
+          {errors.submit && (
+            <div className="error-message submit-error">
+              <i className="bi bi-exclamation-triangle"></i>
+              {errors.submit}
+            </div>
+          )}
 
           <div className="form-actions">
             <button
@@ -255,7 +288,7 @@ const BugReportModal: React.FC<BugReportModalProps> = ({
             <button
               type="submit"
               className="submit-button"
-              disabled={!title.trim() || !content.trim() || !category || isSubmitting}
+              disabled={isSubmitting}
             >
               <i className="bi bi-send"></i>
               {isSubmitting ? '送信中...' : '不具合を報告'}

--- a/src/components/BugReportModal.tsx
+++ b/src/components/BugReportModal.tsx
@@ -1,0 +1,270 @@
+import React, { useState } from 'react';
+import './BugReportModal.css';
+
+interface BugReportModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (bugReport: {
+    title: string;
+    content: string;
+    category: string;
+    severity: string;
+    steps: string;
+    expectedBehavior: string;
+    actualBehavior: string;
+  }) => Promise<void>;
+}
+
+const BugReportModal: React.FC<BugReportModalProps> = ({
+  isOpen,
+  onClose,
+  onSubmit,
+}) => {
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [category, setCategory] = useState('');
+  const [severity, setSeverity] = useState('medium');
+  const [steps, setSteps] = useState('');
+  const [expectedBehavior, setExpectedBehavior] = useState('');
+  const [actualBehavior, setActualBehavior] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const categories = [
+    { value: 'ui', label: 'UI/UX問題' },
+    { value: 'functionality', label: '機能不具合' },
+    { value: 'performance', label: 'パフォーマンス問題' },
+    { value: 'data', label: 'データ関連' },
+    { value: 'login', label: 'ログイン・認証' },
+    { value: 'api', label: 'API関連' },
+    { value: 'other', label: 'その他' },
+  ];
+
+  const severities = [
+    { value: 'low', label: '低' },
+    { value: 'medium', label: '中' },
+    { value: 'high', label: '高' },
+    { value: 'critical', label: '緊急' },
+  ];
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    
+    if (!title.trim() || !content.trim() || !category) {
+      alert('タイトル、内容、カテゴリは必須項目です。');
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await onSubmit({
+        title: title.trim(),
+        content: content.trim(),
+        category,
+        severity,
+        steps: steps.trim(),
+        expectedBehavior: expectedBehavior.trim(),
+        actualBehavior: actualBehavior.trim(),
+      });
+      
+      // フォームをリセット
+      setTitle('');
+      setContent('');
+      setCategory('');
+      setSeverity('medium');
+      setSteps('');
+      setExpectedBehavior('');
+      setActualBehavior('');
+      onClose();
+    } catch (error) {
+      console.error('不具合報告の送信に失敗しました:', error);
+      alert('不具合報告の送信に失敗しました。もう一度お試しください。');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleClose = () => {
+    if (!isSubmitting) {
+      onClose();
+    }
+  };
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="bug-report-modal-overlay">
+      <div className="bug-report-modal">
+        <div className="bug-report-modal-header">
+          <h2>
+            <i className="bi bi-bug"></i>
+            不具合を報告
+          </h2>
+          <button
+            onClick={handleClose}
+            className="close-button"
+            disabled={isSubmitting}
+            title="閉じる"
+            aria-label="モーダルを閉じる"
+          >
+            <i className="bi bi-x"></i>
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="bug-report-form">
+          <div className="form-group">
+            <label htmlFor="title">
+              <i className="bi bi-card-text"></i>
+              タイトル <span className="required">*</span>
+            </label>
+            <input
+              type="text"
+              id="title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="不具合のタイトルを入力してください"
+              disabled={isSubmitting}
+              maxLength={100}
+              required
+            />
+            <div className="character-count">{title.length}/100</div>
+          </div>
+
+          <div className="form-row">
+            <div className="form-group">
+              <label htmlFor="category">
+                <i className="bi bi-tags"></i>
+                カテゴリ <span className="required">*</span>
+              </label>
+              <select
+                id="category"
+                value={category}
+                onChange={(e) => setCategory(e.target.value)}
+                disabled={isSubmitting}
+                required
+              >
+                <option value="">カテゴリを選択してください</option>
+                {categories.map((cat) => (
+                  <option key={cat.value} value={cat.value}>
+                    {cat.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="severity">
+                <i className="bi bi-exclamation-triangle"></i>
+                重要度
+              </label>
+              <select
+                id="severity"
+                value={severity}
+                onChange={(e) => setSeverity(e.target.value)}
+                disabled={isSubmitting}
+              >
+                {severities.map((sev) => (
+                  <option key={sev.value} value={sev.value}>
+                    {sev.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="steps">
+              <i className="bi bi-list-ol"></i>
+              再現手順
+            </label>
+            <textarea
+              id="steps"
+              value={steps}
+              onChange={(e) => setSteps(e.target.value)}
+              placeholder="不具合を再現するための手順を入力してください"
+              disabled={isSubmitting}
+              rows={3}
+              maxLength={500}
+            />
+            <div className="character-count">{steps.length}/500</div>
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="expectedBehavior">
+              <i className="bi bi-check-circle"></i>
+              期待される動作
+            </label>
+            <textarea
+              id="expectedBehavior"
+              value={expectedBehavior}
+              onChange={(e) => setExpectedBehavior(e.target.value)}
+              placeholder="本来期待される動作を入力してください"
+              disabled={isSubmitting}
+              rows={2}
+              maxLength={300}
+            />
+            <div className="character-count">{expectedBehavior.length}/300</div>
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="actualBehavior">
+              <i className="bi bi-x-circle"></i>
+              実際の動作
+            </label>
+            <textarea
+              id="actualBehavior"
+              value={actualBehavior}
+              onChange={(e) => setActualBehavior(e.target.value)}
+              placeholder="実際に起こった動作を入力してください"
+              disabled={isSubmitting}
+              rows={2}
+              maxLength={300}
+            />
+            <div className="character-count">{actualBehavior.length}/300</div>
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="content">
+              <i className="bi bi-chat-text"></i>
+              詳細説明 <span className="required">*</span>
+            </label>
+            <textarea
+              id="content"
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              placeholder="不具合の詳細を入力してください。エラーメッセージ、スクリーンショットの説明なども含めてください。"
+              disabled={isSubmitting}
+              rows={4}
+              maxLength={1000}
+              required
+            />
+            <div className="character-count">{content.length}/1000</div>
+          </div>
+
+          <div className="form-actions">
+            <button
+              type="button"
+              onClick={handleClose}
+              className="cancel-button"
+              disabled={isSubmitting}
+            >
+              <i className="bi bi-x-circle"></i>
+              キャンセル
+            </button>
+            <button
+              type="submit"
+              className="submit-button"
+              disabled={!title.trim() || !content.trim() || !category || isSubmitting}
+            >
+              <i className="bi bi-send"></i>
+              {isSubmitting ? '送信中...' : '不具合を報告'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default BugReportModal;

--- a/src/components/BugReportModal.tsx
+++ b/src/components/BugReportModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import './BugReportModal.css';
+import { getBugReportCategories } from '../utils/requestFormatters';
 
 interface BugReportModalProps {
   isOpen: boolean;
@@ -30,15 +31,7 @@ const BugReportModal: React.FC<BugReportModalProps> = ({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errors, setErrors] = useState<{[key: string]: string}>({});
 
-  const categories = [
-    { value: 'ui', label: 'UI/UX問題' },
-    { value: 'functionality', label: '機能不具合' },
-    { value: 'performance', label: 'パフォーマンス問題' },
-    { value: 'data', label: 'データ関連' },
-    { value: 'login', label: 'ログイン・認証' },
-    { value: 'api', label: 'API関連' },
-    { value: 'other', label: 'その他' },
-  ];
+  const categories = getBugReportCategories();
 
   const severities = [
     { value: 'low', label: '低' },

--- a/src/components/HeaderComponent.css
+++ b/src/components/HeaderComponent.css
@@ -62,7 +62,7 @@
   flex-wrap: wrap; /* 必要に応じて折り返し */
 }
 
-/* 右上固定：シェアボタンとログアウトボタン */
+/* 右上固定：シェアボタン、更新要望ボタン、ログアウトボタン */
 .header-top-right {
   position: absolute;
   top: 1rem;
@@ -73,6 +73,36 @@
   visibility: visible !important;
   opacity: 1 !important;
   z-index: 20; /* 他の要素より上に表示 */
+}
+
+/* 更新要望ボタン */
+.update-request-button {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  background: linear-gradient(135deg, #4ecdc4 0%, #44a08d 100%);
+  color: white;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 600;
+  transition: all 0.3s ease;
+  box-shadow: 0 2px 8px rgba(78, 205, 196, 0.3);
+}
+
+.update-request-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(78, 205, 196, 0.4);
+}
+
+.update-request-button i {
+  font-size: 1rem;
+}
+
+.update-request-button span {
+  font-size: 0.85rem;
 }
 
 /* ユーザー情報 - シンプル化 */

--- a/src/components/HeaderComponent.css
+++ b/src/components/HeaderComponent.css
@@ -62,7 +62,7 @@
   flex-wrap: wrap; /* 必要に応じて折り返し */
 }
 
-/* 右上固定：シェアボタン、更新要望ボタン、ログアウトボタン */
+/* 右上固定：シェアボタン、不具合報告ボタン、更新要望ボタン、ログアウトボタン */
 .header-top-right {
   position: absolute;
   top: 1rem;
@@ -73,6 +73,36 @@
   visibility: visible !important;
   opacity: 1 !important;
   z-index: 20; /* 他の要素より上に表示 */
+}
+
+/* 不具合報告ボタン */
+.bug-report-button {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  background: linear-gradient(135deg, #ff6b6b 0%, #ee5a52 100%);
+  color: white;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 600;
+  transition: all 0.3s ease;
+  box-shadow: 0 2px 8px rgba(255, 107, 107, 0.3);
+}
+
+.bug-report-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(255, 107, 107, 0.4);
+}
+
+.bug-report-button i {
+  font-size: 1rem;
+}
+
+.bug-report-button span {
+  font-size: 0.85rem;
 }
 
 /* 更新要望ボタン */

--- a/src/components/HeaderComponent.tsx
+++ b/src/components/HeaderComponent.tsx
@@ -25,6 +25,7 @@ interface HeaderComponentProps {
   setShowFeatureSettings: (show: boolean) => void;
   loadUserSettings: () => void;
   isTimeTrackingActive: boolean;
+  onUpdateRequestClick: () => void;
 }
 
 const HeaderComponent: React.FC<HeaderComponentProps> = ({
@@ -41,6 +42,7 @@ const HeaderComponent: React.FC<HeaderComponentProps> = ({
   setShowFeatureSettings,
   loadUserSettings,
   isTimeTrackingActive,
+  onUpdateRequestClick,
 }) => {
   return (
     <header className="dashboard-header">
@@ -92,9 +94,17 @@ const HeaderComponent: React.FC<HeaderComponentProps> = ({
         </div>
       </div>
 
-      {/* 右上固定：シェアボタンとログアウトボタン */}
+      {/* 右上固定：シェアボタン、更新要望ボタン、ログアウトボタン */}
       <div className="header-top-right">
         <ShareButtonComponent />
+        <button
+          onClick={onUpdateRequestClick}
+          className="update-request-button"
+          title="更新要望を送信"
+        >
+          <i className="bi bi-lightbulb"></i>
+          <span>更新要望</span>
+        </button>
         <LogoutButtonComponent onLogout={handleLogout} />
       </div>
 

--- a/src/components/HeaderComponent.tsx
+++ b/src/components/HeaderComponent.tsx
@@ -26,6 +26,7 @@ interface HeaderComponentProps {
   loadUserSettings: () => void;
   isTimeTrackingActive: boolean;
   onUpdateRequestClick: () => void;
+  onBugReportClick: () => void;
 }
 
 const HeaderComponent: React.FC<HeaderComponentProps> = ({
@@ -43,6 +44,7 @@ const HeaderComponent: React.FC<HeaderComponentProps> = ({
   loadUserSettings,
   isTimeTrackingActive,
   onUpdateRequestClick,
+  onBugReportClick,
 }) => {
   return (
     <header className="dashboard-header">
@@ -94,9 +96,17 @@ const HeaderComponent: React.FC<HeaderComponentProps> = ({
         </div>
       </div>
 
-      {/* 右上固定：シェアボタン、更新要望ボタン、ログアウトボタン */}
+      {/* 右上固定：シェアボタン、不具合報告ボタン、更新要望ボタン、ログアウトボタン */}
       <div className="header-top-right">
         <ShareButtonComponent />
+        <button
+          onClick={onBugReportClick}
+          className="bug-report-button"
+          title="不具合を報告"
+        >
+          <i className="bi bi-bug"></i>
+          <span>不具合報告</span>
+        </button>
         <button
           onClick={onUpdateRequestClick}
           className="update-request-button"

--- a/src/components/MemosComponent.tsx
+++ b/src/components/MemosComponent.tsx
@@ -218,7 +218,18 @@ const MemosComponent: React.FC<MemosComponentProps> = ({
   const getMemoCategories = () => {
     const memoCategories = new Set(memos.map((memo) => memo.category));
     const allCategories = [...memoCategories, ...getAllCategories()];
-    return Array.from(new Set(allCategories)).sort();
+    
+    // 不具合報告・更新要望に関連するカテゴリを除外
+    const excludedCategories = [
+      'エラー報告', '更新リクエスト', '更新要望', '要望、リクエスト',
+      '不具合報告', 'バグ報告', '改善要望', 'フィードバック'
+    ];
+    
+    const filteredCategories = allCategories.filter(category => 
+      !excludedCategories.includes(category)
+    );
+    
+    return Array.from(new Set(filteredCategories)).sort();
   };
 
   // メモの件数を計算する関数（個人メモ + 公開メモ）

--- a/src/components/MemosComponent.tsx
+++ b/src/components/MemosComponent.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import './MemosComponent.css';
 import type { Memo, Reply } from '../types';
+import { EXCLUDED_MEMO_CATEGORIES } from '../utils/requestFormatters';
 
 interface MemosComponentProps {
   memos: Memo[];
@@ -220,13 +221,10 @@ const MemosComponent: React.FC<MemosComponentProps> = ({
     const allCategories = [...memoCategories, ...getAllCategories()];
     
     // 不具合報告・更新要望に関連するカテゴリを除外
-    const excludedCategories = [
-      'エラー報告', '更新リクエスト', '更新要望', '要望、リクエスト',
-      '不具合報告', 'バグ報告', '改善要望', 'フィードバック'
-    ];
+    const excludedCategories = EXCLUDED_MEMO_CATEGORIES;
     
     const filteredCategories = allCategories.filter(category => 
-      !excludedCategories.includes(category)
+      !excludedCategories.includes(category as any)
     );
     
     return Array.from(new Set(filteredCategories)).sort();

--- a/src/components/MemosComponent.tsx
+++ b/src/components/MemosComponent.tsx
@@ -224,7 +224,7 @@ const MemosComponent: React.FC<MemosComponentProps> = ({
     const excludedCategories = EXCLUDED_MEMO_CATEGORIES;
     
     const filteredCategories = allCategories.filter(category => 
-      !excludedCategories.includes(category as any)
+      !excludedCategories.includes(category)
     );
     
     return Array.from(new Set(filteredCategories)).sort();

--- a/src/components/PublicMemosComponent.tsx
+++ b/src/components/PublicMemosComponent.tsx
@@ -192,7 +192,7 @@ const PublicMemosComponent: React.FC<PublicMemosComponentProps> = ({
     const excludedCategories = EXCLUDED_MEMO_CATEGORIES;
     
     const filteredCategories = allCategories.filter(category => 
-      !excludedCategories.includes(category as any)
+      !excludedCategories.includes(category)
     );
     
     return Array.from(new Set(filteredCategories)).sort();

--- a/src/components/PublicMemosComponent.tsx
+++ b/src/components/PublicMemosComponent.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import './PublicMemosComponent.css';
 import type { Memo, Reply, User } from '../types';
+import { EXCLUDED_MEMO_CATEGORIES } from '../utils/requestFormatters';
 
 interface PublicMemosComponentProps {
   publicMemos: Memo[];
@@ -188,13 +189,10 @@ const PublicMemosComponent: React.FC<PublicMemosComponentProps> = ({
     const allCategories = [...memoCategories, ...getAllGenres()];
     
     // 不具合報告・更新要望に関連するカテゴリを除外
-    const excludedCategories = [
-      'エラー報告', '更新リクエスト', '更新要望', '要望、リクエスト',
-      '不具合報告', 'バグ報告', '改善要望', 'フィードバック'
-    ];
+    const excludedCategories = EXCLUDED_MEMO_CATEGORIES;
     
     const filteredCategories = allCategories.filter(category => 
-      !excludedCategories.includes(category)
+      !excludedCategories.includes(category as any)
     );
     
     return Array.from(new Set(filteredCategories)).sort();

--- a/src/components/PublicMemosComponent.tsx
+++ b/src/components/PublicMemosComponent.tsx
@@ -178,7 +178,7 @@ const PublicMemosComponent: React.FC<PublicMemosComponentProps> = ({
   const getAllGenres = () => {
     return [
       "仕事", "学習", "趣味", "健康", "家族", "旅行", "読書", "映画", "音楽",
-      "スポーツ", "料理", "要望、リクエスト", "その他",
+      "スポーツ", "料理", "その他",
     ];
   };
 
@@ -186,7 +186,18 @@ const PublicMemosComponent: React.FC<PublicMemosComponentProps> = ({
   const getPublicMemoCategories = () => {
     const memoCategories = new Set((publicMemos || []).map((memo) => memo.category));
     const allCategories = [...memoCategories, ...getAllGenres()];
-    return Array.from(new Set(allCategories)).sort();
+    
+    // 不具合報告・更新要望に関連するカテゴリを除外
+    const excludedCategories = [
+      'エラー報告', '更新リクエスト', '更新要望', '要望、リクエスト',
+      '不具合報告', 'バグ報告', '改善要望', 'フィードバック'
+    ];
+    
+    const filteredCategories = allCategories.filter(category => 
+      !excludedCategories.includes(category)
+    );
+    
+    return Array.from(new Set(filteredCategories)).sort();
   };
 
   // 選択された日付の公開メモを取得

--- a/src/components/UpdateRequestModal.css
+++ b/src/components/UpdateRequestModal.css
@@ -1,0 +1,271 @@
+/* UpdateRequestModal.css - 更新要望モーダルのスタイル */
+
+.update-request-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  backdrop-filter: blur(4px);
+}
+
+.update-request-modal {
+  background: white;
+  border-radius: 16px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  width: 90%;
+  max-width: 600px;
+  max-height: 90vh;
+  overflow-y: auto;
+  animation: modalSlideIn 0.3s ease-out;
+}
+
+@keyframes modalSlideIn {
+  from {
+    opacity: 0;
+    transform: translateY(-20px) scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.update-request-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 2rem;
+  border-bottom: 2px solid #f0f0f0;
+  background: linear-gradient(135deg, #4ecdc4 0%, #44a08d 100%);
+  color: white;
+  border-radius: 16px 16px 0 0;
+}
+
+.update-request-modal-header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.update-request-modal-header h2 i {
+  font-size: 1.3rem;
+}
+
+.close-button {
+  background: rgba(255, 255, 255, 0.2);
+  border: none;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: white;
+  font-size: 1.2rem;
+  transition: all 0.2s ease;
+}
+
+.close-button:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.3);
+  transform: scale(1.1);
+}
+
+.close-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.update-request-form {
+  padding: 2rem;
+}
+
+.form-group {
+  margin-bottom: 1.5rem;
+}
+
+.form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.form-group label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+  color: #333;
+  font-size: 0.95rem;
+}
+
+.form-group label i {
+  color: #4ecdc4;
+  font-size: 1rem;
+}
+
+.required {
+  color: #e74c3c;
+  font-weight: 700;
+}
+
+.form-group input,
+.form-group select,
+.form-group textarea {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: 2px solid #e0e0e0;
+  border-radius: 8px;
+  font-size: 0.95rem;
+  font-family: inherit;
+  transition: all 0.3s ease;
+  background: #fafafa;
+}
+
+.form-group input:focus,
+.form-group select:focus,
+.form-group textarea:focus {
+  outline: none;
+  border-color: #4ecdc4;
+  background: white;
+  box-shadow: 0 0 0 3px rgba(78, 205, 196, 0.1);
+}
+
+.form-group input:disabled,
+.form-group select:disabled,
+.form-group textarea:disabled {
+  background: #f5f5f5;
+  color: #999;
+  cursor: not-allowed;
+}
+
+.form-group textarea {
+  resize: vertical;
+  min-height: 120px;
+  line-height: 1.6;
+}
+
+.character-count {
+  text-align: right;
+  font-size: 0.8rem;
+  color: #666;
+  margin-top: 0.25rem;
+}
+
+.form-actions {
+  display: flex;
+  gap: 1rem;
+  justify-content: flex-end;
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid #e0e0e0;
+}
+
+.cancel-button,
+.submit-button {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  min-width: 120px;
+  justify-content: center;
+}
+
+.cancel-button {
+  background: #f8f9fa;
+  color: #6c757d;
+  border: 2px solid #e9ecef;
+}
+
+.cancel-button:hover:not(:disabled) {
+  background: #e9ecef;
+  color: #495057;
+  transform: translateY(-1px);
+}
+
+.submit-button {
+  background: linear-gradient(135deg, #4ecdc4 0%, #44a08d 100%);
+  color: white;
+  box-shadow: 0 4px 12px rgba(78, 205, 196, 0.3);
+}
+
+.submit-button:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(78, 205, 196, 0.4);
+}
+
+.submit-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.cancel-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+}
+
+/* レスポンシブ対応 */
+@media (max-width: 768px) {
+  .update-request-modal {
+    width: 95%;
+    margin: 1rem;
+  }
+  
+  .update-request-modal-header {
+    padding: 1rem 1.5rem;
+  }
+  
+  .update-request-modal-header h2 {
+    font-size: 1.3rem;
+  }
+  
+  .update-request-form {
+    padding: 1.5rem;
+  }
+  
+  .form-row {
+    grid-template-columns: 1fr;
+    gap: 0;
+  }
+  
+  .form-actions {
+    flex-direction: column;
+  }
+  
+  .cancel-button,
+  .submit-button {
+    width: 100%;
+  }
+}
+
+@media (max-width: 480px) {
+  .update-request-modal {
+    width: 100%;
+    height: 100%;
+    border-radius: 0;
+    max-height: none;
+  }
+  
+  .update-request-modal-header {
+    border-radius: 0;
+  }
+}

--- a/src/components/UpdateRequestModal.css
+++ b/src/components/UpdateRequestModal.css
@@ -149,6 +149,35 @@
   cursor: not-allowed;
 }
 
+.form-group input.error,
+.form-group select.error,
+.form-group textarea.error {
+  border-color: #e74c3c;
+  background: #fdf2f2;
+}
+
+.error-message {
+  color: #e74c3c;
+  font-size: 0.85rem;
+  margin-top: 0.25rem;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.error-message i {
+  font-size: 0.9rem;
+}
+
+.submit-error {
+  background: #fdf2f2;
+  border: 1px solid #fecaca;
+  border-radius: 6px;
+  padding: 0.75rem;
+  margin-bottom: 1rem;
+  color: #dc2626;
+}
+
 .form-group textarea {
   resize: vertical;
   min-height: 120px;

--- a/src/components/UpdateRequestModal.tsx
+++ b/src/components/UpdateRequestModal.tsx
@@ -1,0 +1,206 @@
+import React, { useState } from 'react';
+import './UpdateRequestModal.css';
+
+interface UpdateRequestModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (updateRequest: {
+    title: string;
+    content: string;
+    category: string;
+    priority: string;
+  }) => Promise<void>;
+}
+
+const UpdateRequestModal: React.FC<UpdateRequestModalProps> = ({
+  isOpen,
+  onClose,
+  onSubmit,
+}) => {
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [category, setCategory] = useState('');
+  const [priority, setPriority] = useState('medium');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const categories = [
+    { value: 'ui', label: 'UI/UX改善' },
+    { value: 'feature', label: '新機能追加' },
+    { value: 'performance', label: 'パフォーマンス改善' },
+    { value: 'bugfix', label: 'バグ修正' },
+    { value: 'accessibility', label: 'アクセシビリティ' },
+    { value: 'other', label: 'その他' },
+  ];
+
+  const priorities = [
+    { value: 'low', label: '低' },
+    { value: 'medium', label: '中' },
+    { value: 'high', label: '高' },
+    { value: 'urgent', label: '緊急' },
+  ];
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    
+    if (!title.trim() || !content.trim() || !category) {
+      alert('タイトル、内容、カテゴリは必須項目です。');
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await onSubmit({
+        title: title.trim(),
+        content: content.trim(),
+        category,
+        priority,
+      });
+      
+      // フォームをリセット
+      setTitle('');
+      setContent('');
+      setCategory('');
+      setPriority('medium');
+      onClose();
+    } catch (error) {
+      console.error('更新要望の送信に失敗しました:', error);
+      alert('更新要望の送信に失敗しました。もう一度お試しください。');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleClose = () => {
+    if (!isSubmitting) {
+      onClose();
+    }
+  };
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="update-request-modal-overlay">
+      <div className="update-request-modal">
+        <div className="update-request-modal-header">
+          <h2>
+            <i className="bi bi-lightbulb"></i>
+            更新要望を送信
+          </h2>
+          <button
+            onClick={handleClose}
+            className="close-button"
+            disabled={isSubmitting}
+            title="閉じる"
+            aria-label="モーダルを閉じる"
+          >
+            <i className="bi bi-x"></i>
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="update-request-form">
+          <div className="form-group">
+            <label htmlFor="title">
+              <i className="bi bi-card-text"></i>
+              タイトル <span className="required">*</span>
+            </label>
+            <input
+              type="text"
+              id="title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="更新要望のタイトルを入力してください"
+              disabled={isSubmitting}
+              maxLength={100}
+              required
+            />
+            <div className="character-count">{title.length}/100</div>
+          </div>
+
+          <div className="form-row">
+            <div className="form-group">
+              <label htmlFor="category">
+                <i className="bi bi-tags"></i>
+                カテゴリ <span className="required">*</span>
+              </label>
+              <select
+                id="category"
+                value={category}
+                onChange={(e) => setCategory(e.target.value)}
+                disabled={isSubmitting}
+                required
+              >
+                <option value="">カテゴリを選択してください</option>
+                {categories.map((cat) => (
+                  <option key={cat.value} value={cat.value}>
+                    {cat.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="priority">
+                <i className="bi bi-flag"></i>
+                優先度
+              </label>
+              <select
+                id="priority"
+                value={priority}
+                onChange={(e) => setPriority(e.target.value)}
+                disabled={isSubmitting}
+              >
+                {priorities.map((pri) => (
+                  <option key={pri.value} value={pri.value}>
+                    {pri.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="content">
+              <i className="bi bi-chat-text"></i>
+              詳細内容 <span className="required">*</span>
+            </label>
+            <textarea
+              id="content"
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              placeholder="更新要望の詳細を入力してください。具体的な改善点や期待する動作を記述してください。"
+              disabled={isSubmitting}
+              rows={6}
+              maxLength={1000}
+              required
+            />
+            <div className="character-count">{content.length}/1000</div>
+          </div>
+
+          <div className="form-actions">
+            <button
+              type="button"
+              onClick={handleClose}
+              className="cancel-button"
+              disabled={isSubmitting}
+            >
+              <i className="bi bi-x-circle"></i>
+              キャンセル
+            </button>
+            <button
+              type="submit"
+              className="submit-button"
+              disabled={!title.trim() || !content.trim() || !category || isSubmitting}
+            >
+              <i className="bi bi-send"></i>
+              {isSubmitting ? '送信中...' : '更新要望を送信'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default UpdateRequestModal;

--- a/src/components/UpdateRequestModal.tsx
+++ b/src/components/UpdateRequestModal.tsx
@@ -22,6 +22,7 @@ const UpdateRequestModal: React.FC<UpdateRequestModalProps> = ({
   const [category, setCategory] = useState('');
   const [priority, setPriority] = useState('medium');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errors, setErrors] = useState<{[key: string]: string}>({});
 
   const categories = [
     { value: 'ui', label: 'UI/UX改善' },
@@ -39,15 +40,33 @@ const UpdateRequestModal: React.FC<UpdateRequestModalProps> = ({
     { value: 'urgent', label: '緊急' },
   ];
 
+  const validateForm = () => {
+    const newErrors: {[key: string]: string} = {};
+    
+    if (!title.trim()) {
+      newErrors.title = 'タイトルは必須項目です。';
+    }
+    if (!content.trim()) {
+      newErrors.content = '内容は必須項目です。';
+    }
+    if (!category) {
+      newErrors.category = 'カテゴリは必須項目です。';
+    }
+    
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     
-    if (!title.trim() || !content.trim() || !category) {
-      alert('タイトル、内容、カテゴリは必須項目です。');
+    if (!validateForm()) {
       return;
     }
 
     setIsSubmitting(true);
+    setErrors({});
+    
     try {
       await onSubmit({
         title: title.trim(),
@@ -61,10 +80,11 @@ const UpdateRequestModal: React.FC<UpdateRequestModalProps> = ({
       setContent('');
       setCategory('');
       setPriority('medium');
+      setErrors({});
       onClose();
     } catch (error) {
       console.error('更新要望の送信に失敗しました:', error);
-      alert('更新要望の送信に失敗しました。もう一度お試しください。');
+      setErrors({ submit: '更新要望の送信に失敗しました。もう一度お試しください。' });
     } finally {
       setIsSubmitting(false);
     }
@@ -114,8 +134,10 @@ const UpdateRequestModal: React.FC<UpdateRequestModalProps> = ({
               disabled={isSubmitting}
               maxLength={100}
               required
+              className={errors.title ? 'error' : ''}
             />
             <div className="character-count">{title.length}/100</div>
+            {errors.title && <div className="error-message">{errors.title}</div>}
           </div>
 
           <div className="form-row">
@@ -130,6 +152,7 @@ const UpdateRequestModal: React.FC<UpdateRequestModalProps> = ({
                 onChange={(e) => setCategory(e.target.value)}
                 disabled={isSubmitting}
                 required
+                className={errors.category ? 'error' : ''}
               >
                 <option value="">カテゴリを選択してください</option>
                 {categories.map((cat) => (
@@ -138,6 +161,7 @@ const UpdateRequestModal: React.FC<UpdateRequestModalProps> = ({
                   </option>
                 ))}
               </select>
+              {errors.category && <div className="error-message">{errors.category}</div>}
             </div>
 
             <div className="form-group">
@@ -174,9 +198,18 @@ const UpdateRequestModal: React.FC<UpdateRequestModalProps> = ({
               rows={6}
               maxLength={1000}
               required
+              className={errors.content ? 'error' : ''}
             />
             <div className="character-count">{content.length}/1000</div>
+            {errors.content && <div className="error-message">{errors.content}</div>}
           </div>
+
+          {errors.submit && (
+            <div className="error-message submit-error">
+              <i className="bi bi-exclamation-triangle"></i>
+              {errors.submit}
+            </div>
+          )}
 
           <div className="form-actions">
             <button
@@ -191,7 +224,7 @@ const UpdateRequestModal: React.FC<UpdateRequestModalProps> = ({
             <button
               type="submit"
               className="submit-button"
-              disabled={!title.trim() || !content.trim() || !category || isSubmitting}
+              disabled={isSubmitting}
             >
               <i className="bi bi-send"></i>
               {isSubmitting ? '送信中...' : '更新要望を送信'}

--- a/src/components/UpdateRequestModal.tsx
+++ b/src/components/UpdateRequestModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import './UpdateRequestModal.css';
+import { getUpdateRequestCategories } from '../utils/requestFormatters';
 
 interface UpdateRequestModalProps {
   isOpen: boolean;
@@ -24,14 +25,7 @@ const UpdateRequestModal: React.FC<UpdateRequestModalProps> = ({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errors, setErrors] = useState<{[key: string]: string}>({});
 
-  const categories = [
-    { value: 'ui', label: 'UI/UX改善' },
-    { value: 'feature', label: '新機能追加' },
-    { value: 'performance', label: 'パフォーマンス改善' },
-    { value: 'bugfix', label: 'バグ修正' },
-    { value: 'accessibility', label: 'アクセシビリティ' },
-    { value: 'other', label: 'その他' },
-  ];
+  const categories = getUpdateRequestCategories();
 
   const priorities = [
     { value: 'low', label: '低' },

--- a/src/constants/version.ts
+++ b/src/constants/version.ts
@@ -1,5 +1,5 @@
 // アプリケーションのバージョン情報
-export const APP_VERSION = "1.0.4";
+export const APP_VERSION = "1.0.5";
 
 // 更新履歴の型定義
 export interface ChangelogEntry {
@@ -11,6 +11,21 @@ export interface ChangelogEntry {
 
 // 更新履歴
 export const CHANGELOG: ChangelogEntry[] = [
+  {
+    version: "1.0.5",
+    date: "2025-01-21",
+    changes: [
+      "更新要望送信機能を追加（専用UIとモーダル）",
+      "不具合報告機能を追加（詳細な報告フォーム）",
+      "メモ機能から不具合報告・更新要望関連カテゴリを分離",
+      "エラーハンドリングの改善（alertから個別フィールドエラー表示に変更）",
+      "カテゴリ管理の一元化とコードの重複削除",
+      "フォームバリデーションの強化とユーザビリティ向上",
+      "コンテンツフォーマット用ユーティリティ関数の追加",
+      "コードの保守性と一貫性を大幅に改善"
+    ],
+    type: "feature"
+  },
   {
     version: "1.0.4",
     date: "2025-01-21",

--- a/src/utils/requestFormatters.ts
+++ b/src/utils/requestFormatters.ts
@@ -17,21 +17,25 @@ export interface BugReportData {
   actualBehavior: string;
 }
 
-// カテゴリラベルのマッピング
-const CATEGORY_LABELS = {
-  // 更新要望カテゴリ
+// 更新要望カテゴリラベルのマッピング
+export const UPDATE_REQUEST_CATEGORY_LABELS = {
   ui: 'UI/UX改善',
   feature: '新機能追加',
   performance: 'パフォーマンス改善',
   bugfix: 'バグ修正',
   accessibility: 'アクセシビリティ',
   other: 'その他',
-  
-  // 不具合報告カテゴリ
+} as const;
+
+// 不具合報告カテゴリラベルのマッピング
+export const BUG_REPORT_CATEGORY_LABELS = {
+  ui: 'UI/UX問題',
   functionality: '機能不具合',
+  performance: 'パフォーマンス問題',
   data: 'データ関連',
   login: 'ログイン・認証',
   api: 'API関連',
+  other: 'その他',
 } as const;
 
 // 優先度ラベルのマッピング
@@ -54,7 +58,7 @@ const SEVERITY_LABELS = {
  * 更新要望のコンテンツをフォーマットする
  */
 export const formatUpdateRequestContent = (data: UpdateRequestData): string => {
-  const categoryLabel = CATEGORY_LABELS[data.category as keyof typeof CATEGORY_LABELS] || data.category;
+  const categoryLabel = UPDATE_REQUEST_CATEGORY_LABELS[data.category as keyof typeof UPDATE_REQUEST_CATEGORY_LABELS] || data.category;
   const priorityLabel = PRIORITY_LABELS[data.priority as keyof typeof PRIORITY_LABELS] || data.priority;
   
   return `**カテゴリ:** ${categoryLabel}
@@ -68,7 +72,7 @@ ${data.content}`;
  * 不具合報告のコンテンツをフォーマットする
  */
 export const formatBugReportContent = (data: BugReportData): string => {
-  const categoryLabel = CATEGORY_LABELS[data.category as keyof typeof CATEGORY_LABELS] || data.category;
+  const categoryLabel = BUG_REPORT_CATEGORY_LABELS[data.category as keyof typeof BUG_REPORT_CATEGORY_LABELS] || data.category;
   const severityLabel = SEVERITY_LABELS[data.severity as keyof typeof SEVERITY_LABELS] || data.severity;
   
   return `**カテゴリ:** ${categoryLabel}
@@ -114,3 +118,37 @@ export const formatUpdateRequestTitle = (title: string): string => {
 export const formatBugReportTitle = (title: string): string => {
   return `[不具合報告] ${title}`;
 };
+
+/**
+ * 更新要望のカテゴリ配列を取得する
+ */
+export const getUpdateRequestCategories = () => {
+  return Object.entries(UPDATE_REQUEST_CATEGORY_LABELS).map(([value, label]) => ({
+    value,
+    label,
+  }));
+};
+
+/**
+ * 不具合報告のカテゴリ配列を取得する
+ */
+export const getBugReportCategories = () => {
+  return Object.entries(BUG_REPORT_CATEGORY_LABELS).map(([value, label]) => ({
+    value,
+    label,
+  }));
+};
+
+/**
+ * メモ機能から除外するカテゴリの定数
+ */
+export const EXCLUDED_MEMO_CATEGORIES = [
+  'エラー報告',
+  '更新リクエスト', 
+  '更新要望',
+  '要望、リクエスト',
+  '不具合報告',
+  'バグ報告',
+  '改善要望',
+  'フィードバック'
+];

--- a/src/utils/requestFormatters.ts
+++ b/src/utils/requestFormatters.ts
@@ -1,0 +1,116 @@
+// 更新要望・不具合報告のコンテンツフォーマット用ユーティリティ
+
+export interface UpdateRequestData {
+  title: string;
+  content: string;
+  category: string;
+  priority: string;
+}
+
+export interface BugReportData {
+  title: string;
+  content: string;
+  category: string;
+  severity: string;
+  steps: string;
+  expectedBehavior: string;
+  actualBehavior: string;
+}
+
+// カテゴリラベルのマッピング
+const CATEGORY_LABELS = {
+  // 更新要望カテゴリ
+  ui: 'UI/UX改善',
+  feature: '新機能追加',
+  performance: 'パフォーマンス改善',
+  bugfix: 'バグ修正',
+  accessibility: 'アクセシビリティ',
+  other: 'その他',
+  
+  // 不具合報告カテゴリ
+  functionality: '機能不具合',
+  data: 'データ関連',
+  login: 'ログイン・認証',
+  api: 'API関連',
+} as const;
+
+// 優先度ラベルのマッピング
+const PRIORITY_LABELS = {
+  low: '低',
+  medium: '中',
+  high: '高',
+  urgent: '緊急',
+} as const;
+
+// 重要度ラベルのマッピング
+const SEVERITY_LABELS = {
+  low: '低',
+  medium: '中',
+  high: '高',
+  critical: '緊急',
+} as const;
+
+/**
+ * 更新要望のコンテンツをフォーマットする
+ */
+export const formatUpdateRequestContent = (data: UpdateRequestData): string => {
+  const categoryLabel = CATEGORY_LABELS[data.category as keyof typeof CATEGORY_LABELS] || data.category;
+  const priorityLabel = PRIORITY_LABELS[data.priority as keyof typeof PRIORITY_LABELS] || data.priority;
+  
+  return `**カテゴリ:** ${categoryLabel}
+**優先度:** ${priorityLabel}
+
+**詳細内容:**
+${data.content}`;
+};
+
+/**
+ * 不具合報告のコンテンツをフォーマットする
+ */
+export const formatBugReportContent = (data: BugReportData): string => {
+  const categoryLabel = CATEGORY_LABELS[data.category as keyof typeof CATEGORY_LABELS] || data.category;
+  const severityLabel = SEVERITY_LABELS[data.severity as keyof typeof SEVERITY_LABELS] || data.severity;
+  
+  return `**カテゴリ:** ${categoryLabel}
+**重要度:** ${severityLabel}
+
+**再現手順:**
+${data.steps || '記載なし'}
+
+**期待される動作:**
+${data.expectedBehavior || '記載なし'}
+
+**実際の動作:**
+${data.actualBehavior || '記載なし'}
+
+**詳細説明:**
+${data.content}`;
+};
+
+/**
+ * 更新要望のタグを取得する
+ */
+export const getUpdateRequestTags = (): string[] => {
+  return ['更新要望', '改善提案', 'フィードバック'];
+};
+
+/**
+ * 不具合報告のタグを取得する
+ */
+export const getBugReportTags = (): string[] => {
+  return ['不具合報告', 'バグ', 'エラー'];
+};
+
+/**
+ * 更新要望のタイトルをフォーマットする
+ */
+export const formatUpdateRequestTitle = (title: string): string => {
+  return `[更新要望] ${title}`;
+};
+
+/**
+ * 不具合報告のタイトルをフォーマットする
+ */
+export const formatBugReportTitle = (title: string): string => {
+  return `[不具合報告] ${title}`;
+};


### PR DESCRIPTION
## 概要
更新要望を投稿するためのUIを追加しました。

## 実装内容
- **ヘッダーに更新要望ボタンを追加**: 右上のナビゲーションエリアに更新要望ボタンを配置
- **更新要望専用モーダル**: カテゴリ、優先度、詳細内容を入力できる専用フォーム
- **API連携**: 既存のメモAPIを使用して更新要望を送信
- **レスポンシブデザイン**: モバイルタブレットデスクトップに対応
- **アクセシビリティ**: 適切なラベルとARIA属性を設定

## 技術詳細
- UpdateRequestModal.tsx: 更新要望専用のモーダルコンポーネント
- HeaderComponent.tsx: 更新要望ボタンを追加
- App.tsx: 更新要望の状態管理とハンドラーを実装
- 既存のメモAPIのpostType: 'update_request'を使用

## テスト
- [x] 更新要望ボタンの表示確認
- [x] モーダルの開閉動作確認
- [x] フォーム送信機能確認
- [x] レスポンシブデザイン確認

## 関連Issue
更新要望を投稿するUIが不足していた問題を解決