### PR TITLE
fix: versionMessagesの初期化エラーを修正

### DIFF
--- a/src/components/ShareButtonComponent.tsx
+++ b/src/components/ShareButtonComponent.tsx
@@ -20,10 +20,12 @@ const getVersionMessages = (version: string) => [
   `v${version}でユーザーエクスペリエンスが向上！`
 ];
 
-// バージョン紹介文言の配列をメモ化（APP_VERSIONは実行時に変更されないため）
-const versionMessages = getVersionMessages(APP_VERSION);
+
+
 
 const ShareButtonComponent: React.FC<ShareButtonComponentProps> = ({ className = '' }) => {
+  // バージョン紹介文言の配列をメモ化（APP_VERSIONは実行時に変更されないため）
+  const versionMessages = useMemo(() => getVersionMessages(APP_VERSION), []);
   const [isOpen, setIsOpen] = useState(false);
   const [randomElements, setRandomElements] = useState(() => generateRandomElements());
   const [stats, setStats] = useState({

--- a/src/components/ShareButtonComponent.tsx
+++ b/src/components/ShareButtonComponent.tsx
@@ -220,7 +220,7 @@ const ShareButtonComponent: React.FC<ShareButtonComponentProps> = ({ className =
     }
     
     // 文字数制限を超える場合は短縮版を使用
-    // Fallback: omit stats and latest update info for brevity
+    // Fallback: Omit stats and latest update info for brevity
     const shortVersionInfo = elements.versionMsg;
     return `${siteTitle}\n\n${baseText}${shortVersionInfo}\n\n${siteUrl}`;
   };

--- a/src/components/ShareButtonComponent.tsx
+++ b/src/components/ShareButtonComponent.tsx
@@ -6,18 +6,18 @@ interface ShareButtonComponentProps {
   className?: string;
 }
 
-// バージョン紹介文言の配列（コンポーネント外で定義）
-const versionMessages = [
-  `最新バージョン${APP_VERSION}で更新要望・不具合報告機能を追加！`,
-  `v${APP_VERSION}でユーザビリティが大幅に向上しました！`,
-  `新機能満載のv${APP_VERSION}をぜひお試しください！`,
-  `v${APP_VERSION}でエラーハンドリングが改善されました！`,
-  `最新アップデートv${APP_VERSION}でより使いやすく！`,
-  `v${APP_VERSION}で新機能と改善が追加されました！`,
-  `最新版v${APP_VERSION}でパフォーマンスが向上！`,
-  `v${APP_VERSION}でコード品質が大幅に改善されました！`,
-  `新バージョンv${APP_VERSION}で機能が充実！`,
-  `v${APP_VERSION}でユーザーエクスペリエンスが向上！`
+// バージョン紹介文言の配列を生成する関数
+const getVersionMessages = (version: string) => [
+  `最新バージョン${version}で更新要望・不具合報告機能を追加！`,
+  `v${version}でユーザビリティが大幅に向上しました！`,
+  `新機能満載のv${version}をぜひお試しください！`,
+  `v${version}でエラーハンドリングが改善されました！`,
+  `最新アップデートv${version}でより使いやすく！`,
+  `v${version}で新機能と改善が追加されました！`,
+  `最新版v${version}でパフォーマンスが向上！`,
+  `v${version}でコード品質が大幅に改善されました！`,
+  `新バージョンv${version}で機能が充実！`,
+  `v${version}でユーザーエクスペリエンスが向上！`
 ];
 
 const ShareButtonComponent: React.FC<ShareButtonComponentProps> = ({ className = '' }) => {
@@ -122,6 +122,9 @@ const ShareButtonComponent: React.FC<ShareButtonComponentProps> = ({ className =
     const randomActivity = activities[Math.floor(Math.random() * activities.length)];
     const randomFeatures = features.sort(() => 0.5 - Math.random()).slice(0, 3);
     const randomBenefit = benefits[Math.floor(Math.random() * benefits.length)];
+    
+    // バージョン紹介文言を動的に生成
+    const versionMessages = getVersionMessages(APP_VERSION);
     const randomVersionMessage = versionMessages[Math.floor(Math.random() * versionMessages.length)];
     
     return {

--- a/src/components/ShareButtonComponent.tsx
+++ b/src/components/ShareButtonComponent.tsx
@@ -181,22 +181,37 @@ const ShareButtonComponent: React.FC<ShareButtonComponentProps> = ({ className =
     return statsParts.length > 0 ? `\n\n📊 現在の状況: ${statsParts.join('、')}` : '';
   };
   
-  const getSiteDescription = () => {
+  // 基礎テキスト要素を生成するユーティリティ関数
+  const generateBaseTextElements = () => {
     const intro = `${randomElements.adjective}${randomElements.character}と一緒に${randomElements.activity}ができるWebアプリです。`;
     const features = `${randomElements.features.join('、')}など、${randomElements.benefit}をサポートします。`;
     const promise = `ユーザーから要求があった機能をすぐに実装します！`;
     const versionMsg = `\n\n${randomElements.versionMessage}`;
     const latestUpdate = getLatestUpdateInfo();
     const statsText = getStatsText();
-    return `${intro}${features}${promise}${versionMsg}${latestUpdate}${statsText}`;
+    
+    return {
+      intro,
+      features,
+      promise,
+      versionMsg,
+      latestUpdate,
+      statsText
+    };
+  };
+
+  const getSiteDescription = () => {
+    const elements = generateBaseTextElements();
+    return `${elements.intro}${elements.features}${elements.promise}${elements.versionMsg}${elements.latestUpdate}${elements.statsText}`;
   };
 
   const siteDescription = getSiteDescription();
   
   // Twitter用の短縮テキストを生成する関数
   const generateTwitterText = () => {
-    const baseText = `${randomElements.adjective}${randomElements.character}と一緒に${randomElements.activity}ができるWebアプリです。`;
-    const versionInfo = `\n\n${randomElements.versionMessage}${getLatestUpdateInfo()}${getStatsText()}`;
+    const elements = generateBaseTextElements();
+    const baseText = elements.intro;
+    const versionInfo = `${elements.versionMsg}${elements.latestUpdate}${elements.statsText}`;
     const fullText = `${siteTitle}\n\n${baseText}${versionInfo}\n\n${siteUrl}`;
     
     const maxTwitterLength = 280;
@@ -206,7 +221,7 @@ const ShareButtonComponent: React.FC<ShareButtonComponentProps> = ({ className =
     
     // 文字数制限を超える場合は短縮版を使用
     // Fallback: omit stats and latest update info for brevity
-    const shortVersionInfo = `\n\n${randomElements.versionMessage}`;
+    const shortVersionInfo = elements.versionMsg;
     return `${siteTitle}\n\n${baseText}${shortVersionInfo}\n\n${siteUrl}`;
   };
   

--- a/src/components/ShareButtonComponent.tsx
+++ b/src/components/ShareButtonComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useMemo } from 'react';
 import './ShareButtonComponent.css';
 import { APP_VERSION, getLatestChangelog } from '../constants/version';
 

--- a/src/components/ShareButtonComponent.tsx
+++ b/src/components/ShareButtonComponent.tsx
@@ -20,6 +20,9 @@ const getVersionMessages = (version: string) => [
   `v${version}でユーザーエクスペリエンスが向上！`
 ];
 
+// バージョン紹介文言の配列をメモ化（APP_VERSIONは実行時に変更されないため）
+const versionMessages = getVersionMessages(APP_VERSION);
+
 const ShareButtonComponent: React.FC<ShareButtonComponentProps> = ({ className = '' }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [randomElements, setRandomElements] = useState(() => generateRandomElements());
@@ -123,8 +126,7 @@ const ShareButtonComponent: React.FC<ShareButtonComponentProps> = ({ className =
     const randomFeatures = features.sort(() => 0.5 - Math.random()).slice(0, 3);
     const randomBenefit = benefits[Math.floor(Math.random() * benefits.length)];
     
-    // バージョン紹介文言を動的に生成
-    const versionMessages = getVersionMessages(APP_VERSION);
+    // バージョン紹介文言を動的に生成（メモ化された配列を使用）
     const randomVersionMessage = versionMessages[Math.floor(Math.random() * versionMessages.length)];
     
     return {
@@ -142,7 +144,9 @@ const ShareButtonComponent: React.FC<ShareButtonComponentProps> = ({ className =
   // 最新の更新履歴を取得
   const getLatestUpdateInfo = () => {
     const latestChangelog = getLatestChangelog();
-    if (!latestChangelog) return '';
+    if (!latestChangelog) {
+      return '';
+    }
     
     const typeLabels = {
       bugfix: "🐛 バグ修正",

--- a/src/components/ShareButtonComponent.tsx
+++ b/src/components/ShareButtonComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import './ShareButtonComponent.css';
 import { APP_VERSION, getLatestChangelog } from '../constants/version';
 
@@ -181,8 +181,8 @@ const ShareButtonComponent: React.FC<ShareButtonComponentProps> = ({ className =
     return statsParts.length > 0 ? `\n\n📊 現在の状況: ${statsParts.join('、')}` : '';
   };
   
-  // 基礎テキスト要素を生成するユーティリティ関数
-  const generateBaseTextElements = () => {
+  // 基礎テキスト要素を生成するユーティリティ関数（メモ化）
+  const baseTextElements = useMemo(() => {
     const intro = `${randomElements.adjective}${randomElements.character}と一緒に${randomElements.activity}ができるWebアプリです。`;
     const features = `${randomElements.features.join('、')}など、${randomElements.benefit}をサポートします。`;
     const promise = `ユーザーから要求があった機能をすぐに実装します！`;
@@ -198,20 +198,18 @@ const ShareButtonComponent: React.FC<ShareButtonComponentProps> = ({ className =
       latestUpdate,
       statsText
     };
-  };
+  }, [randomElements, stats.loading, stats.userCount, stats.errorCount, stats.updateRequestCount, stats.linterErrorCount, stats.testErrorCount]);
 
   const getSiteDescription = () => {
-    const elements = generateBaseTextElements();
-    return `${elements.intro}${elements.features}${elements.promise}${elements.versionMsg}${elements.latestUpdate}${elements.statsText}`;
+    return `${baseTextElements.intro}${baseTextElements.features}${baseTextElements.promise}${baseTextElements.versionMsg}${baseTextElements.latestUpdate}${baseTextElements.statsText}`;
   };
 
   const siteDescription = getSiteDescription();
   
   // Twitter用の短縮テキストを生成する関数
   const generateTwitterText = () => {
-    const elements = generateBaseTextElements();
-    const baseText = elements.intro;
-    const versionInfo = `${elements.versionMsg}${elements.latestUpdate}${elements.statsText}`;
+    const baseText = baseTextElements.intro;
+    const versionInfo = `${baseTextElements.versionMsg}${baseTextElements.latestUpdate}${baseTextElements.statsText}`;
     const fullText = `${siteTitle}\n\n${baseText}${versionInfo}\n\n${siteUrl}`;
     
     const maxTwitterLength = 280;
@@ -220,8 +218,8 @@ const ShareButtonComponent: React.FC<ShareButtonComponentProps> = ({ className =
     }
     
     // 文字数制限を超える場合は短縮版を使用
-    // Fallback: Omit stats and latest update info for brevity
-    const shortVersionInfo = elements.versionMsg;
+    // Fallback: omit stats and latest update info for brevity
+    const shortVersionInfo = baseTextElements.versionMsg;
     return `${siteTitle}\n\n${baseText}${shortVersionInfo}\n\n${siteUrl}`;
   };
   

--- a/src/components/ShareButtonComponent.tsx
+++ b/src/components/ShareButtonComponent.tsx
@@ -204,7 +204,7 @@ const ShareButtonComponent: React.FC<ShareButtonComponentProps> = ({ className =
       latestUpdate,
       statsText
     };
-  }, [randomElements, stats.loading, stats.userCount, stats.errorCount, stats.updateRequestCount, stats.linterErrorCount, stats.testErrorCount]);
+  }, [randomElements, stats]);
 
   const getSiteDescription = () => {
     return `${baseTextElements.intro}${baseTextElements.features}${baseTextElements.promise}${baseTextElements.versionMsg}${baseTextElements.latestUpdate}${baseTextElements.statsText}`;


### PR DESCRIPTION
## 概要
ShareButtonComponentで発生していた「Cannot access 'G' before initialization」エラーを修正しました。

## 問題
- ersionMessages配列がモジュール読み込み時にAPP_VERSIONを参照
- 変数の初期化順序によりReferenceErrorが発生
- アプリケーションが正常に動作しない状態

## 解決方法
- ersionMessages配列をgetVersionMessages()関数に変更
- 関数内でAPP_VERSIONを動的に参照するように修正
- 初期化順序の問題を根本的に解決

## 技術的詳細
- モジュール読み込み時の静的参照を動的参照に変更
- パフォーマンスへの影響は最小限（軽量な関数呼び出し）
- 既存の機能はすべて維持

## 修正内容
- **Before**: モジュール読み込み時にAPP_VERSIONを参照
- **After**: 関数実行時にAPP_VERSIONを参照
- **効果**: ReferenceErrorを完全に解決

これにより、アプリケーションが正常に動作し、シェア機能のバージョン紹介文言が正しく表示されるようになります。